### PR TITLE
Add standalone theme template

### DIFF
--- a/theme/index.html
+++ b/theme/index.html
@@ -1,0 +1,45 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="utf-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover" />
+  <title>Theme Template</title>
+  <link rel="icon" href="data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 16 16'><text x='0' y='14'>😊</text></svg>" />
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+  <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&display=swap" rel="stylesheet" />
+  <script>
+    window.tailwind = window.tailwind || {};
+    tailwind.config = {
+      theme: {
+        extend: {
+          fontFamily: { sans: ['Inter','ui-sans-serif','system-ui'] },
+          keyframes: {
+            floaty: { '0%':{transform:'translateY(0px)'}, '50%':{transform:'translateY(-8px)'}, '100%':{transform:'translateY(0px)'} }
+          },
+          animation: { floaty:'floaty 6s ease-in-out infinite' }
+        }
+      }
+    }
+  </script>
+  <script src="https://cdn.tailwindcss.com"></script>
+  <link rel="stylesheet" href="./style.css" />
+</head>
+<body class="bg-slate-50 text-slate-900 antialiased">
+  <header class="toolbar">
+    <span class="logo" role="img" aria-label="smile">😊</span>
+    <nav class="social">
+      <a href="https://github.com/luisitinrodriguez2001-cloud" target="_blank" rel="noopener">GitHub</a>
+      <a href="https://twitter.com/" target="_blank" rel="noopener">Twitter</a>
+      <a href="https://www.linkedin.com/" target="_blank" rel="noopener">LinkedIn</a>
+    </nav>
+  </header>
+  <div id="fun-fact" class="fun-fact"></div>
+  <div class="pointer-events-none fixed inset-0 overflow-hidden" aria-hidden="true">
+    <div class="absolute -top-24 -left-24 w-72 h-72 rounded-full bg-gradient-to-br from-amber-200 to-pink-200 blur-3xl opacity-60 animate-floaty"></div>
+    <div class="absolute -bottom-24 -right-24 w-80 h-80 rounded-full bg-gradient-to-br from-emerald-200 to-sky-200 blur-3xl opacity-60 animate-floaty" style="animation-delay:-2.2s;"></div>
+  </div>
+  <main class="relative">
+    <!-- Application content goes here -->
+  </main>
+</body>
+</html>

--- a/theme/style.css
+++ b/theme/style.css
@@ -1,0 +1,26 @@
+/* Theme styles */
+html, body { height: 100%; }
+body {
+  font-family: Inter, ui-sans-serif, system-ui, -apple-system, Segoe UI, Roboto, "Helvetica Neue", Arial, "Apple Color Emoji", "Segoe UI Emoji";
+  text-rendering: optimizeLegibility;
+}
+
+.toolbar{
+  display:flex;
+  justify-content:space-between;
+  align-items:center;
+  padding:.5rem 1rem;
+  background:white;
+  border-bottom:1px solid rgba(15,23,42,.1);
+}
+.toolbar .logo{font-size:1.5rem;}
+.toolbar .social a{
+  margin:0 .25rem;
+  text-decoration:none;
+}
+.fun-fact{
+  background:#fde68a;
+  text-align:center;
+  padding:.5rem 1rem;
+  font-weight:500;
+}


### PR DESCRIPTION
## Summary
- add independent `theme` folder with minimal `index.html` and `style.css`
- template retains header smiley, social links, fun fact ribbon, and gradient background without tool tabs or data

## Testing
- `npm test` (fails: Could not read package.json)

------
https://chatgpt.com/codex/tasks/task_e_68a4d70ee6ec83229bef8059c28a875c