### PR TITLE
Revise lifestyle questionnaire for clarity

### DIFF
--- a/index.html
+++ b/index.html
@@ -85,46 +85,65 @@
             </label>
           </fieldset>
 
-          <fieldset>
-            <legend>Behaviors</legend>
+            <fieldset>
+              <legend>Behaviors</legend>
 
-            <label class="inline">Smoking
-              <button type="button" class="icon-btn" aria-label="Smoking info">
-                i
-                <span class="tooltip" role="tooltip" id="smoking-tip">
-                  <span class="tooltip-content">Select ‘Never’ if you’ve never smoked, ‘Current’ if you smoke now, or ‘Former’ if you quit.</span>
-                </span>
-              </button>
-              <select id="smoking" class="field" aria-describedby="smoking-tip">
-                <option value="never">Never</option>
-                <option value="current">Current</option>
-                <option value="former">Former</option>
-              </select>
-            </label>
+              <hr class="my-4" />
 
-            <label id="ysq-wrap" class="inline" hidden>Years since quit
-              <button type="button" class="icon-btn" aria-label="Years since quit info">
-                i
-                <span class="tooltip" role="tooltip" id="ysq-tip">
-                  <span class="tooltip-content">If you used to smoke, how many years ago you quit. Reduces your hazard ratio as the years increase.</span>
-                </span>
-              </button>
-              <input id="yearsSinceQuit" class="field" type="number" min="0" max="60" placeholder="5" aria-describedby="ysq-tip" />
-            </label>
+              <label class="inline">Smoking
+                <button type="button" class="icon-btn" aria-label="Smoking info">
+                  i
+                  <span class="tooltip" role="tooltip" id="smoking-tip">
+                    <span class="tooltip-content">Select ‘Never’ if you’ve never smoked, ‘Current’ if you smoke now, or ‘Former’ if you quit.</span>
+                  </span>
+                </button>
+                <select id="smoking" class="field" aria-describedby="smoking-tip">
+                  <option value="never">Never</option>
+                  <option value="current">Current</option>
+                  <option value="former">Former</option>
+                </select>
+              </label>
 
-            <label class="inline">Physical activity (MET-hours/week)
-              <button type="button" class="icon-btn" aria-label="Physical activity info">
-                i
-                <span class="tooltip" role="tooltip" id="met-tip">
-                  <span class="tooltip-content">Total weekly physical activity measured in metabolic equivalent hours. 7.5-15 MET-h/wk ≈ 150–300 min moderate exercise.</span>
-                </span>
-              </button>
-              <input id="metHours" class="field" type="number" min="0" max="100" step="0.5" placeholder="10" aria-describedby="met-tip" />
-            </label>
+              <label id="ysq-wrap" class="inline" hidden>Years since quit
+                <button type="button" class="icon-btn" aria-label="Years since quit info">
+                  i
+                  <span class="tooltip" role="tooltip" id="ysq-tip">
+                    <span class="tooltip-content">If you used to smoke, how many years ago you quit. Reduces your hazard ratio as the years increase.</span>
+                  </span>
+                </button>
+                <input id="yearsSinceQuit" class="field" type="number" min="0" max="60" placeholder="5" aria-describedby="ysq-tip" />
+              </label>
 
-            <label class="inline">Weight (lbs)
-              <button type="button" class="icon-btn" aria-label="Weight info">
-                i
+              <label id="alcohol-wrap" class="inline" hidden>Alcohol (drinks/day)
+                <button type="button" class="icon-btn" aria-label="Alcohol info">
+                  i
+                  <span class="tooltip" role="tooltip" id="alcohol-tip">
+                    <span class="tooltip-content">Average number of standard drinks you have per day.</span>
+                  </span>
+                </button>
+                <input id="alcohol" class="field" type="number" min="0" max="10" step="0.1" placeholder="0" aria-describedby="alcohol-tip" />
+              </label>
+
+              <hr class="my-4" />
+
+              <label class="inline">Physical activity
+                <button type="button" class="icon-btn" aria-label="Physical activity info">
+                  i
+                  <span class="tooltip" role="tooltip" id="activity-tip">
+                    <span class="tooltip-content">Select your typical weekly activity. We'll estimate MET-hours/week.</span>
+                  </span>
+                </button>
+                <select id="activityLevel" class="field" aria-describedby="activity-tip">
+                  <option value="none">Little to none</option>
+                  <option value="light">1-2 days light exercise</option>
+                  <option value="moderate">3-5 days moderate exercise</option>
+                  <option value="high">6-7 days vigorous exercise</option>
+                </select>
+              </label>
+
+              <label class="inline">Weight (lbs)
+                <button type="button" class="icon-btn" aria-label="Weight info">
+                  i
                 <span class="tooltip" role="tooltip" id="weight-tip">
                   <span class="tooltip-content">Your weight in pounds (lbs). Used to compute Body Mass Index (BMI).</span>
                 </span>
@@ -132,31 +151,25 @@
               <input id="weight" class="field" type="number" min="50" max="1000" step="0.1" placeholder="160" aria-describedby="weight-tip" />
             </label>
 
-            <label class="inline">Height
-              <button type="button" class="icon-btn" aria-label="Height info">
-                i
-                <span class="tooltip" role="tooltip" id="height-tip">
-                  <span class="tooltip-content">Your height in feet and inches. Also used to compute BMI.</span>
-                </span>
-              </button>
-              <input id="heightFeet" class="field" type="number" min="3" max="8" step="1" placeholder="5" aria-label="Height feet" aria-describedby="height-tip" /> ft
-              <input id="heightInches" class="field" type="number" min="0" max="11" step="1" placeholder="9" aria-label="Height inches" aria-describedby="height-tip" /> in
-            </label>
+              <label class="inline">Height
+                <button type="button" class="icon-btn" aria-label="Height info">
+                  i
+                  <span class="tooltip" role="tooltip" id="height-tip">
+                    <span class="tooltip-content">Your height in feet and inches. Also used to compute BMI.</span>
+                  </span>
+                </button>
+                <div class="flex items-center gap-2">
+                  <input id="heightFeet" class="field w-16" type="number" min="3" max="8" step="1" placeholder="5" aria-label="Height feet" aria-describedby="height-tip" /> <span>ft</span>
+                  <input id="heightInches" class="field w-16" type="number" min="0" max="11" step="1" placeholder="9" aria-label="Height inches" aria-describedby="height-tip" /> <span>in</span>
+                </div>
+              </label>
 
-            <label class="inline">Alcohol (drinks/day)
-              <button type="button" class="icon-btn" aria-label="Alcohol info">
-                i
-                <span class="tooltip" role="tooltip" id="alcohol-tip">
-                  <span class="tooltip-content">Average number of standard drinks you have per day.</span>
-                </span>
-              </button>
-              <input id="alcohol" class="field" type="number" min="0" max="10" step="0.1" placeholder="0" aria-describedby="alcohol-tip" />
-            </label>
+              <hr class="my-4" />
 
-            <small class="disclaimer">
-              Associations, not causation. Hazard ratios drawn from large cohort/meta analyses; simplifications apply.
-            </small>
-          </fieldset>
+              <small class="disclaimer">
+                Associations, not causation. Hazard ratios drawn from large cohort/meta analyses; simplifications apply.
+              </small>
+            </fieldset>
 
           <fieldset id="screening_fs">
             <legend class="inline">Preventive screening

--- a/js/app.js
+++ b/js/app.js
@@ -27,16 +27,35 @@ function wireUI() {
   // Inputs
   bindNumber('age', v => update({ age: clamp(+v,20,100) }));
   bindSelect('sex', v => update({ sex: v }));
+  const alcoholWrap = document.getElementById('alcohol-wrap');
   bindSelect('smoking', v => {
     document.getElementById('ysq-wrap').hidden = (v !== 'former');
-    update({ smoking: v });
+    alcoholWrap.hidden = (v !== 'current');
+    if (v !== 'current') {
+      document.getElementById('alcohol').value = 0;
+      update({ smoking: v, alcoholDrinks: 0 });
+    } else {
+      update({ smoking: v });
+    }
   });
   bindNumber('yearsSinceQuit', v => update({ yearsSinceQuit: Math.max(0, +v||0) }));
-  bindNumber('metHours', v => update({ metHours: Math.max(0, +v||0) }));
+
+  const activityMap = { none:0, light:5, moderate:10, high:20 };
+  const actEl = document.getElementById('activityLevel');
+  const met = s.metHours || 0;
+  actEl.value = met>=20 ? 'high' : met>=10 ? 'moderate' : met>=5 ? 'light' : 'none';
+  actEl.addEventListener('change', ev => update({ metHours: activityMap[ev.target.value] }));
+
   bindNumber('weight', v => update({ weight: Math.max(50, +v||50) }), 'weight');
   bindNumber('heightFeet', v => update({ heightFt: Math.max(3, +v||3) }), 'heightFt');
   bindNumber('heightInches', v => update({ heightIn: Math.max(0, Math.min(11, +v||0)) }), 'heightIn');
-  bindNumber('alcohol', v => update({ alcoholDrinks: Math.max(0, +v||0) }));
+  bindNumber('alcohol', v => update({ alcoholDrinks: Math.max(0, +v||0) }), 'alcoholDrinks');
+
+  alcoholWrap.hidden = (s.smoking !== 'current');
+  if (s.smoking !== 'current') {
+    document.getElementById('alcohol').value = 0;
+    update({ alcoholDrinks: 0 });
+  }
 
   const crcEl = document.getElementById('crc_screen');
   crcEl.checked = s.crc;


### PR DESCRIPTION
## Summary
- Replace raw MET-hours input with activity level selection to estimate METs
- Group smoking and alcohol questions and only request drinks for current smokers
- Align height fields and add separators for clearer layout

## Testing
- `npm test` *(fails: could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a4dec417d883228cccb8c35c1c29fb