### PR TITLE
Improve charts spacing, percentages, theme, and life expectancy display

### DIFF
--- a/index.html
+++ b/index.html
@@ -25,6 +25,7 @@
     }
   </script>
   <script src="https://cdn.tailwindcss.com"></script>
+  <link rel="stylesheet" href="./theme/style.css" />
   <link rel="stylesheet" href="./style.css" />
 </head>
 <body class="bg-slate-50 text-slate-900 antialiased">
@@ -208,7 +209,7 @@
 
         <div id="summary" aria-live="polite">
           <div class="stat">
-            <div class="stat-label">Remaining life expectancy</div>
+            <div class="stat-label">Life expectancy (age)</div>
             <div class="stat-value">
               <span id="le_baseline">–</span> → <span id="le_adjusted">–</span>
             </div>

--- a/js/app.js
+++ b/js/app.js
@@ -7,6 +7,7 @@ import './ui.js'; // sets up UI listeners and exposes helpers
 
 let worker;
 let datasets;
+let currentAge = 0;
 
 async function init() {
   datasets = await loadAllData();
@@ -107,6 +108,7 @@ function wireUI() {
 
 function run() {
   const st = getStateForWorker();
+  currentAge = +st.age;
   worker.postMessage({ cmd:'run', payload: st });
 }
 
@@ -114,8 +116,8 @@ function onWorkerMessage(e) {
   const msg = e.data;
   if (msg.ready) return;
   // update summary numbers
-  q('#le_baseline').textContent = fix2(msg.le_baseline);
-  q('#le_adjusted').textContent = fix2(msg.le_adj);
+  q('#le_baseline').textContent = fix2(currentAge + msg.le_baseline);
+  q('#le_adjusted').textContent = fix2(currentAge + msg.le_adj);
   q('#le_delta').textContent    = addSign(fix2(msg.le_delta));
 
   if (msg.hale_baseline != null) {
@@ -140,14 +142,14 @@ function onWorkerMessage(e) {
   drawLines('survivalChart', [
     { name:'Baseline', x: msg.survival.age, y: msg.survival.S_base },
     { name:'Adjusted', x: msg.survival.age, y: msg.survival.S_adj }
-  ], { yLabel:'Survival S(x)', xLabel:'Age', disclaimer:true });
+  ], { yLabel:'Survival', xLabel:'Age', yPercent:true, disclaimer:true });
 
   const oneMinusS = msg.survival.S_base.map((v,i)=>1-v);
   const oneMinusSa= msg.survival.S_adj.map((v,i)=>1-v);
   drawLines('cdfChart', [
     { name:'Baseline', x: msg.survival.age, y: oneMinusS },
     { name:'Adjusted', x: msg.survival.age, y: oneMinusSa }
-  ], { yLabel:'Cumulative probability of death', xLabel:'Age', disclaimer:true });
+  ], { yLabel:'Cumulative probability of death', xLabel:'Age', yPercent:true, disclaimer:true });
 }
 
 function getStateForWorker(){

--- a/js/charts.js
+++ b/js/charts.js
@@ -3,7 +3,7 @@ export function drawLines(containerId, series, opts={}){
   const el = document.getElementById(containerId);
   if (!el) return;
   el.innerHTML = '';
-  const W = el.clientWidth || 640, H = el.clientHeight || 280, m={t:20,r:15,b:30,l:40};
+  const W = el.clientWidth || 640, H = el.clientHeight || 280, m={t:20,r:15,b:40,l:40};
   const svg = h('svg',{viewBox:`0 0 ${W} ${H}`,width:'100%',height:'100%',role:'img'});
   el.appendChild(svg);
 
@@ -11,7 +11,8 @@ export function drawLines(containerId, series, opts={}){
   const xs = series.flatMap(s=>s.x);
   const ys = series.flatMap(s=>s.y);
   const xMin = Math.min(...xs), xMax = Math.max(...xs);
-  const yMin = Math.min(0, ...ys), yMax = Math.max(1, ...ys);
+  const yMin = Math.min(0, ...ys);
+  const yMax = opts.yPercent ? 1 : Math.max(1, ...ys);
 
   const sx = v => m.l + (v-xMin)/(xMax-xMin) * (W-m.l-m.r);
   const sy = v => H - m.b - (v-yMin)/(yMax-yMin) * (H-m.t-m.b);
@@ -26,8 +27,12 @@ export function drawLines(containerId, series, opts={}){
   for (let a = Math.ceil(xMin/10)*10; a<=xMax; a+=10){
     const x=sx(a); line(x,H-m.b,x,H-m.b+4,'#aaa'); text(x,H-m.b+18,''+a,'middle');
   }
-  for (let p=0; p<=1.0001; p+=0.25){
-    const y=sy(p); line(m.l,y,m.l-4,y,'#aaa'); text(m.l-8,y,''+p,'end','middle');
+  const yStep = opts.yPercent ? 0.25 : 0.25;
+  for (let p=0; p<=1.0001; p+=yStep){
+    const y=sy(p);
+    const label = opts.yPercent ? `${Math.round(p*100)}%` : ''+p;
+    line(m.l,y,m.l-4,y,'#aaa');
+    text(m.l-8,y,label,'end','middle');
   }
 
   // lines

--- a/style.css
+++ b/style.css
@@ -1,5 +1,3 @@
-@import "./theme/style.css";
-
 /* Overrides and additional program-specific styles */
 
 /* Ensure touch targets */
@@ -59,7 +57,8 @@ input[type="checkbox"]{ min-width:44px; }
 .stat-label{font-size:.9rem;opacity:.8}
 .stat-value{font-size:1.25rem;font-weight:600}
 .stat-delta{color:var(--accent,#1a7f37)}
-.chart{height:280px}
+.chart{height:280px;margin-bottom:1rem}
+.chart + .chart{margin-top:1rem}
 .inline{display:flex;align-items:center;gap:.5rem}
 .disclaimer{font-size:.85rem;opacity:.8}
 #assumptionsModal{max-width:min(760px,90vw)}


### PR DESCRIPTION
## Summary
- Include theme stylesheet and show life expectancy as age
- Display chart y-axes as percentages with extra spacing
- Expand chart margins to prevent axis overlap

## Testing
- `npx playwright test tests/tests.html` *(fails: No tests found)*

------
https://chatgpt.com/codex/tasks/task_e_68a4e0ce152c832281ea7c5051f8c1c7