### PR TITLE
feat: apply fitness toolkit header theme

### DIFF
--- a/index.html
+++ b/index.html
@@ -29,25 +29,43 @@
   <link rel="stylesheet" href="./style.css" />
 </head>
 <body class="bg-slate-50 text-slate-900 antialiased">
-  <header class="toolbar">
-    <span class="logo" role="img" aria-label="smile">😊</span>
-    <nav class="social">
-      <a href="https://github.com/luisitinrodriguez2001-cloud" target="_blank" rel="noopener">GitHub</a>
-      <a href="https://twitter.com/" target="_blank" rel="noopener">Twitter</a>
-      <a href="https://www.linkedin.com/" target="_blank" rel="noopener">LinkedIn</a>
-    </nav>
-    <div class="tool-picker">
+  <div class="pointer-events-none fixed inset-0 overflow-hidden" aria-hidden="true">
+    <div class="absolute -top-24 -left-24 w-72 h-72 rounded-full bg-gradient-to-br from-amber-200 to-pink-200 blur-3xl opacity-60 animate-floaty"></div>
+    <div class="absolute -bottom-24 -right-24 w-80 h-80 rounded-full bg-gradient-to-br from-emerald-200 to-sky-200 blur-3xl opacity-60 animate-floaty" style="animation-delay:-2.2s;"></div>
+  </div>
+  <header class="max-w-5xl mx-auto px-4 py-6 bg-white/80 backdrop-blur border border-slate-200 rounded-xl shadow">
+    <div class="flex flex-col sm:flex-row items-start sm:items-center gap-4 mb-4 animate-fadeUp">
+      <div class="w-16 h-16 rounded-2xl bg-yellow-100 flex items-center justify-center text-3xl shadow bouncy select-none" aria-hidden="true" title="Hi!">🙂</div>
+      <div class="flex-1 min-w-0">
+        <h1 class="text-2xl md:text-3xl font-bold tracking-tight">Actuarial Toolkit</h1>
+        <p class="text-slate-600">Crunch the numbers and outwit risk.</p>
+      </div>
+      <nav class="flex items-center gap-4 text-sm" aria-label="Social">
+        <a class="inline-flex items-center gap-1 underline" href="https://twitter.com/" target="_blank" rel="noopener">Twitter</a>
+        <span class="text-slate-400">&bull;</span>
+        <a class="inline-flex items-center gap-1 underline" href="https://www.linkedin.com/" target="_blank" rel="noopener">LinkedIn</a>
+      </nav>
+    </div>
+    <div class="mt-3 flex items-center justify-between text-sm text-slate-600 border border-slate-200 rounded-lg bg-white/80 px-3 py-2 shadow">
+      <div class="flex items-center gap-2">
+        <span class="px-2 py-0.5 rounded bg-slate-100">Fun fact</span>
+        <span id="fun-fact" class="animate-fadeUp text-slate-600"></span>
+      </div>
+      <button id="shuffle-fact" class="icon-btn hover:bg-slate-100" aria-label="Shuffle fun fact" title="Shuffle fun fact">
+        <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" class="w-4 h-4" fill="currentColor">
+          <path d="M7 3v2h.59L5 8.59 6.41 10 10 6.41V7h2V3H7zm10 0h4v4h-2V6.41l-3.29 3.3-1.42-1.42L17.59 5H17V3zM3 13h4v-2H3v2zm6.71 3.29 1.42 1.42L5 23h2v-2h.59l3.3-3.29-1.18-1.42zM19 14h2v4h-4v-2h1.59l-3.29-3.29 1.42-1.42L19 14.59V14z"/>
+        </svg>
+      </button>
+    </div>
+  </header>
+
+  <div class="max-w-5xl mx-auto px-4 mb-4">
+    <div class="flex items-center gap-2">
       <label for="toolSelect">Pick a tool:</label>
       <select id="toolSelect" class="field">
         <option value="longevity-lab" selected>Longevity Lab</option>
       </select>
     </div>
-  </header>
-  <div id="fun-fact" class="fun-fact"></div>
-
-  <div class="pointer-events-none fixed inset-0 overflow-hidden" aria-hidden="true">
-    <div class="absolute -top-24 -left-24 w-72 h-72 rounded-full bg-gradient-to-br from-amber-200 to-pink-200 blur-3xl opacity-60 animate-floaty"></div>
-    <div class="absolute -bottom-24 -right-24 w-80 h-80 rounded-full bg-gradient-to-br from-emerald-200 to-sky-200 blur-3xl opacity-60 animate-floaty" style="animation-delay:-2.2s;"></div>
   </div>
 
   <main class="relative">

--- a/js/ui.js
+++ b/js/ui.js
@@ -13,15 +13,26 @@ import { setState, getState } from './state.js';
     const s = getState();
     document.getElementById('ysq-wrap').hidden = (s.smoking!=='former');
 
-    // fun facts ribbon
+    // fun facts
     const facts = [
       'Honey never spoils.',
       'A group of flamingos is called a flamboyance.',
       'Bananas are berries, but strawberries are not.'
     ];
     const ff = document.getElementById('fun-fact');
-    if (ff) {
-      ff.textContent = facts[Math.floor(Math.random()*facts.length)];
+    const shuffle = document.getElementById('shuffle-fact');
+    if (ff && facts.length) {
+      let idx = Math.floor(Math.random() * facts.length);
+      ff.textContent = facts[idx];
+      if (shuffle) {
+        shuffle.addEventListener('click', () => {
+          idx = (idx + 1) % facts.length;
+          ff.textContent = facts[idx];
+        });
+      }
+    } else if (ff) {
+      ff.textContent = 'No facts yet.';
+      if (shuffle) shuffle.disabled = true;
     }
 
     // simple tool picker

--- a/style.css
+++ b/style.css
@@ -65,24 +65,3 @@ input[type="checkbox"]{ min-width:44px; }
 .assumptions-body{max-height:70vh;overflow:auto}
 .contrib .chip{display:inline-block;margin:.125rem .25rem;padding:.25rem .5rem;border-radius:999px;background:var(--chip,#f1f1f1);font-size:.85rem}
 
-/* Basic header with social links and tool picker */
-.toolbar{
-  display:flex;
-  justify-content:space-between;
-  align-items:center;
-  padding:.5rem 1rem;
-  background:white;
-  border-bottom:1px solid rgba(15,23,42,.1);
-}
-.toolbar .logo{font-size:1.5rem;}
-.toolbar .social a{
-  margin:0 .25rem;
-  text-decoration:none;
-}
-.tool-picker label{margin-right:.25rem;}
-.fun-fact{
-  background:#fde68a;
-  text-align:center;
-  padding:.5rem 1rem;
-  font-weight:500;
-}


### PR DESCRIPTION
## Summary
- Make header translucent with backdrop blur and remove GitHub link
- Box fun fact ribbon to match Fitness Toolkit styling
- Move ambient gradient behind header

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a4e3c126f48322acc7ccc705f1bc26