### PR TITLE
Include current age in HALE calculations

### DIFF
--- a/js/app.js
+++ b/js/app.js
@@ -121,8 +121,8 @@ function onWorkerMessage(e) {
   q('#le_delta').textContent    = addSign(fix2(msg.le_delta));
 
   if (msg.hale_baseline != null) {
-    q('#hale_baseline').textContent = fix2(msg.hale_baseline);
-    q('#hale_adjusted').textContent = fix2(msg.hale_adj);
+    q('#hale_baseline').textContent = fix2(currentAge + msg.hale_baseline);
+    q('#hale_adjusted').textContent = fix2(currentAge + msg.hale_adj);
     q('#hale_delta').textContent    = addSign(fix2(msg.hale_delta));
     document.getElementById('hale-row').hidden = false;
   } else {


### PR DESCRIPTION
## Summary
- Add current age to baseline and adjusted HALE values so outputs show total age rather than just additional years.

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a4ea14e6fc8322b60004304cfdd645