### PR TITLE
Toggle tooltips via click and reposition arrow

### DIFF
--- a/js/ui.js
+++ b/js/ui.js
@@ -2,6 +2,27 @@
 import { setState, getState } from './state.js';
 
 (function(){
+  function positionTooltip(btn){
+    const tip = btn.querySelector('.tooltip');
+    if(!tip) return;
+    const rect = btn.getBoundingClientRect();
+    tip.style.position = 'fixed';
+    tip.style.top = `${rect.bottom + 6}px`;
+    tip.style.left = `${rect.left + rect.width/2}px`;
+    const tRect = tip.getBoundingClientRect();
+    const vpCenter = window.innerWidth/2;
+    const arrow = Math.max(8, Math.min(tRect.width-8, vpCenter - tRect.left));
+    tip.style.setProperty('--arrow-left', `${arrow}px`);
+  }
+
+  function closeAll(){
+    document.querySelectorAll('.icon-btn[data-open]').forEach(btn=>{
+      btn.removeAttribute('data-open');
+      const tip = btn.querySelector('.tooltip');
+      if(tip) tip.removeAttribute('style');
+    });
+  }
+
   document.addEventListener('change', e=>{
     if (e.target?.id==='smoking'){
       document.getElementById('ysq-wrap').hidden = (e.target.value!=='former');
@@ -46,5 +67,31 @@ import { setState, getState } from './state.js';
       picker.addEventListener('change', e=> show(e.target.value));
       show(picker.value);
     }
+
+    // tooltip toggling
+    const icons = document.querySelectorAll('.icon-btn');
+    icons.forEach(btn=>{
+      const tip = btn.querySelector('.tooltip');
+      if(!tip) return;
+      btn.addEventListener('click', ev=>{
+        ev.stopPropagation();
+        const open = btn.hasAttribute('data-open');
+        closeAll();
+        if(!open){
+          btn.setAttribute('data-open','');
+          positionTooltip(btn);
+        }
+      });
+    });
+
+    document.addEventListener('click', closeAll);
+    document.addEventListener('keydown', e=>{ if(e.key==='Escape') closeAll(); });
+
+    const reposition = ()=>{
+      const open = document.querySelector('.icon-btn[data-open]');
+      if(open) positionTooltip(open);
+    };
+    window.addEventListener('scroll', reposition, { passive:true });
+    window.addEventListener('resize', reposition);
   });
 })();

--- a/style.css
+++ b/style.css
@@ -6,8 +6,7 @@ select, input[type="checkbox"]{ min-height:44px; }
 input[type="checkbox"]{ min-width:44px; }
 
 /* Show tooltips on focus */
-.icon-btn:hover .tooltip,
-.icon-btn:focus .tooltip{
+.icon-btn[data-open] .tooltip{
   pointer-events:auto;
   opacity:1;
   transform: translateX(-50%) translateY(10px) scale(1);

--- a/theme/style.css
+++ b/theme/style.css
@@ -94,13 +94,24 @@ body {
   border-radius: .6rem;
   box-shadow: 0 18px 40px rgba(2,6,23,.12);
   opacity: 0;
+  --arrow-left:50%;
   transition:
     opacity .18s var(--ease-out),
     transform .18s var(--ease-out);
   z-index: 40;
 }
-.icon-btn:hover .tooltip,
-.icon-btn:focus-visible .tooltip{
+.icon-btn .tooltip::before{
+  content:'';
+  position:absolute;
+  top:-6px;
+  left:var(--arrow-left);
+  transform:translateX(-50%) rotate(45deg);
+  width:12px; height:12px;
+  background:inherit;
+  border-left:1px solid rgba(15,23,42,.12);
+  border-top:1px solid rgba(15,23,42,.12);
+}
+.icon-btn[data-open] .tooltip{
   pointer-events: auto;
   opacity: 1;
   transform: translateX(-50%) translateY(10px) scale(1);


### PR DESCRIPTION
## Summary
- Toggle info tooltips via click, ensuring only one opens at a time and repositions on scroll and resize.
- Style tooltips to display when `data-open` is set and include an arrow whose position tracks the viewport center.
- Update overrides to rely on `data-open` for tooltip visibility.

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a4ebcd252c8322a622f709cd03b1f4