### PR TITLE
Add tooltip clarifying life expectancy definitions

### DIFF
--- a/index.html
+++ b/index.html
@@ -235,6 +235,15 @@
         </div>
 
         <div id="summary" aria-live="polite">
+          <div class="flex justify-end mb-2">
+            <button type="button" class="icon-btn" aria-label="Life expectancy explanations">
+              i
+              <span class="tooltip" role="tooltip" id="summary-tip">
+                <span class="tooltip-content">Life expectancy shows expected age at death. Healthy life expectancy counts only years in good health.</span>
+              </span>
+            </button>
+          </div>
+
           <div class="stat">
             <div class="stat-label">Life expectancy (age)</div>
             <div class="stat-value">


### PR DESCRIPTION
## Summary
- Add info button with tooltip in summary area to clarify life expectancy vs healthy life expectancy

## Testing
- `node tests/tests.html` (fails: Unexpected token '<')
- `npx --yes playwright@latest test tests/tests.html` (fails: No tests found)


------
https://chatgpt.com/codex/tasks/task_e_68a4f56b4d388322adea31e6dd37c872