### PR TITLE
Adjust chart layout for narrow viewports

### DIFF
--- a/style.css
+++ b/style.css
@@ -64,3 +64,8 @@ input[type="checkbox"]{ min-width:44px; }
 .assumptions-body{max-height:70vh;overflow:auto}
 .contrib .chip{display:inline-block;margin:.125rem .25rem;padding:.25rem .5rem;border-radius:999px;background:var(--chip,#f1f1f1);font-size:.85rem}
 
+@media(max-width:600px){
+  .chart{height:200px;margin:.5rem 0}
+  .chart + .chart{margin-top:.5rem}
+}
+


### PR DESCRIPTION
## Summary
- Reduce chart height and vertical margins when the viewport is 600px or less to keep charts readable on mobile screens.

## Testing
- `npm test` *(fails: ENOENT package.json)*
- `node -e puppeteer launch` *(verifies chart height 200px and margins 8px)*

------
https://chatgpt.com/codex/tasks/task_e_68a4f6a318988322acfc686191666f1a