### PR TITLE
Refine Longevity Lab UI and clarify metrics

### DIFF
--- a/index.html
+++ b/index.html
@@ -29,7 +29,7 @@
   <link rel="stylesheet" href="./style.css" />
 </head>
 <body class="bg-slate-50 text-slate-900 antialiased">
-  <header class="max-w-5xl mx-auto px-4 py-6 bg-white/70 backdrop-blur rounded-xl shadow">
+  <header class="max-w-5xl mx-auto px-4 py-6 bg-white rounded-xl shadow">
     <div class="flex flex-col sm:flex-row items-start sm:items-center gap-4 mb-4 animate-fadeUp">
       <div class="w-16 h-16 rounded-2xl bg-yellow-100 flex items-center justify-center text-3xl shadow bouncy select-none" aria-hidden="true" title="Hi!">🙂</div>
       <div class="flex-1 min-w-0">
@@ -42,7 +42,7 @@
         <a class="inline-flex items-center gap-1 underline" href="https://www.tiktok.com/@luisitin2001" target="_blank" rel="noopener">TikTok</a>
       </nav>
     </div>
-    <div class="mt-3 flex items-center justify-between text-sm text-slate-600 px-3 py-2 bg-white/70 rounded-lg border">
+    <div class="mt-3 flex items-center justify-between text-sm text-slate-600 px-3 py-2 bg-white rounded-lg border">
       <div class="flex items-center gap-2">
         <span class="px-2 py-0.5 rounded bg-slate-100">Fun fact</span>
         <span id="fun-fact" class="animate-fadeUp text-slate-600"></span>
@@ -71,12 +71,11 @@
 
   <main class="relative">
       <section id="longevity-lab" class="card tool" aria-labelledby="longevity-title">
-        <h2 id="longevity-title">Counterfactual Longevity Lab</h2>
+        <h2 id="longevity-title">Longevity Lab</h2>
 
         <button type="button" class="what-btn" data-toggle="disc-main" aria-expanded="false" aria-controls="disc-main">What is this?</button>
         <p id="disc-main" class="disclaimer" role="note" hidden>
-          Population-level estimates only. Uses U.S. period life table + published hazard ratio associations.
-          Not medical advice. Results are sensitive to assumptions. See “Assumptions &amp; Data Sources.”
+          Population-level estimates from U.S. life tables and hazard ratios. Not medical advice.
         </p>
 
       <div class="grid two-col" id="controls">
@@ -233,8 +232,7 @@
             </div>
             <button type="button" class="what-btn" data-toggle="disclaimer-controls" aria-expanded="false" aria-controls="disclaimer-controls">What is this?</button>
             <small id="disclaimer-controls" class="disclaimer" hidden>
-              This tool uses a period life table (mortality held constant at observed year), proportional-hazards scaling,
-              and screening deltas from external models. It is not personalized medical guidance.
+              Uses period life tables and hazard ratios. Not medical advice.
             </small>
           </div>
 
@@ -243,13 +241,13 @@
             <button type="button" class="icon-btn" aria-label="Life expectancy explanations">
               i
               <span class="tooltip" role="tooltip" id="summary-tip">
-                <span class="tooltip-content">Life expectancy shows expected age at death. Healthy life expectancy counts only years in good health.</span>
+                <span class="tooltip-content">Life expectancy is total expected years. Healthy life expectancy counts only years in good health.</span>
               </span>
             </button>
           </div>
 
           <div class="stat">
-            <div class="stat-label">Life expectancy (age)</div>
+            <div class="stat-label">Life expectancy (total years)</div>
             <div class="stat-value">
               <span id="le_baseline">–</span> → <span id="le_adjusted">–</span>
             </div>
@@ -257,7 +255,7 @@
           </div>
 
           <div class="stat" id="hale-row" hidden>
-            <div class="stat-label">Healthy life expectancy</div>
+            <div class="stat-label">Healthy life expectancy (healthy years)</div>
             <div class="stat-value">
               <span id="hale_baseline">–</span> → <span id="hale_adjusted">–</span>
             </div>
@@ -268,7 +266,6 @@
 
           <div class="actions">
             <button id="downloadCsv" type="button">Download CSV</button>
-            <button id="shareState" type="button">Share</button>
           </div>
 
           <button type="button" class="what-btn" data-toggle="disc-csv" aria-expanded="false" aria-controls="disc-csv">What is this?</button>
@@ -279,6 +276,7 @@
       </div>
 
       <div class="chart" id="survivalChart" aria-label="Survival curves baseline vs adjusted"></div>
+      <hr class="graph-divider" />
       <div class="chart" id="cdfChart" aria-label="Cumulative probability of death by age"></div>
 
         <dialog id="assumptionsModal" aria-labelledby="assumptionsTitle">

--- a/js/app.js
+++ b/js/app.js
@@ -72,9 +72,8 @@ function wireUI() {
   document.getElementById('assumptionsBtn').addEventListener('click', ()=> dlg.showModal());
   document.getElementById('closeAssumptions').addEventListener('click', ()=> dlg.close());
 
-  // Export/Share
+  // Export
   document.getElementById('downloadCsv').addEventListener('click', downloadCsv);
-  document.getElementById('shareState').addEventListener('click', shareURL);
 
   // react to state changes
   onStateChange(() => {
@@ -192,13 +191,6 @@ function downloadCsv(){
     worker.onmessage = onWorkerMessage;
   };
   run();
-}
-
-function shareURL(){
-  const url = new URL(location.href);
-  url.searchParams.set('s', btoa(encodeURIComponent(JSON.stringify(getState()))));
-  navigator.clipboard?.writeText(url.toString());
-  alert('Sharable link copied. Reminder: results are population-level; see Assumptions for details.');
 }
 
 function q(sel){ return document.querySelector(sel); }

--- a/js/ui.js
+++ b/js/ui.js
@@ -5,13 +5,9 @@ import { setState, getState } from './state.js';
   function positionTooltip(btn){
     const tip = btn.querySelector('.tooltip');
     if(!tip) return;
-    const rect = btn.getBoundingClientRect();
-    tip.style.position = 'fixed';
-    tip.style.top = `${rect.bottom + 6}px`;
-    tip.style.left = `${rect.left + rect.width/2}px`;
-    const tRect = tip.getBoundingClientRect();
+    const rect = tip.getBoundingClientRect();
     const vpCenter = window.innerWidth/2;
-    const arrow = Math.max(8, Math.min(tRect.width-8, vpCenter - tRect.left));
+    const arrow = Math.max(8, Math.min(rect.width-8, vpCenter - rect.left));
     tip.style.setProperty('--arrow-left', `${arrow}px`);
   }
 
@@ -36,9 +32,9 @@ import { setState, getState } from './state.js';
 
     // fun facts
     const facts = [
-      'Honey never spoils.',
-      'A group of flamingos is called a flamboyance.',
-      'Bananas are berries, but strawberries are not.'
+      'Regular exercise can add years to your life expectancy.',
+      'Smoking can cut life expectancy by up to a decade.',
+      'Healthy diets are linked to longer lifespans.'
     ];
     const ff = document.getElementById('fun-fact');
     const shuffle = document.getElementById('shuffle-fact');

--- a/style.css
+++ b/style.css
@@ -5,6 +5,13 @@
 select, input[type="checkbox"]{ min-height:44px; }
 input[type="checkbox"]{ min-width:44px; }
 
+#qualityToggle{
+  min-width:16px;
+  min-height:16px;
+  width:16px;
+  height:16px;
+}
+
 /* Show tooltips on focus */
 .icon-btn[data-open] .tooltip{
   pointer-events:auto;
@@ -58,6 +65,7 @@ input[type="checkbox"]{ min-width:44px; }
 .stat-delta{color:var(--accent,#1a7f37)}
 .chart{height:280px;margin-bottom:1rem}
 .chart + .chart{margin-top:1rem}
+.graph-divider{border-top:2px solid #e5e7eb;margin:1.5rem 0}
 .inline{display:flex;align-items:center;gap:.5rem}
 .disclaimer{font-size:.85rem;opacity:.8}
 .what-btn{font-size:.85rem;color:rgb(59,130,246);text-decoration:underline;background:none;border:none;padding:0;cursor:pointer}


### PR DESCRIPTION
## Summary
- Make header and fun-fact bar solid and rename "Counterfactual Longevity Lab" to a friendlier title with shorter disclaimers
- Clarify difference between life expectancy and healthy life expectancy, shrink quality toggle, and add spacing divider between charts
- Remove share button, align info tooltips correctly, and swap in longevity-themed fun facts

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a50194198083228ffefa7e3fea8728