### PR TITLE
Convert alcohol and screening questions to dropdowns

### DIFF
--- a/index.html
+++ b/index.html
@@ -141,7 +141,15 @@
                     <span class="tooltip-content">Average number of standard drinks you have per day.</span>
                   </span>
                 </button>
-                <input id="alcohol" class="field" type="number" min="0" max="10" step="0.1" placeholder="0" aria-describedby="alcohol-tip" />
+                <select id="alcohol" class="field" aria-describedby="alcohol-tip">
+                  <option value="0">None</option>
+                  <option value="1">1/day</option>
+                  <option value="2">2/day</option>
+                  <option value="3">3/day</option>
+                  <option value="4">4/day</option>
+                  <option value="5">5/day</option>
+                  <option value="6">6+/day</option>
+                </select>
               </label>
 
               <hr class="my-4" />
@@ -201,16 +209,26 @@
                 </span>
               </button>
             </legend>
-            <label id="crc_wrap" hidden>
-              <input type="checkbox" id="crc_screen" />
-              Have you gotten a colorectal screening done?
+            <div id="crc_wrap" hidden>
+              <label class="inline" for="crc_screen">
+                <span class="flex-1">Have you gotten a colorectal screening done?</span>
+                <select id="crc_screen" class="field">
+                  <option value="no">No</option>
+                  <option value="yes">Yes</option>
+                </select>
+              </label>
               <span class="block text-slate-600 text-sm">Helps detect colorectal cancer early.</span>
-            </label>
-            <label id="breast_wrap" hidden>
-              <input type="checkbox" id="breast_screen" />
-              Have you gotten a breast cancer screening done?
+            </div>
+            <div id="breast_wrap" hidden>
+              <label class="inline" for="breast_screen">
+                <span class="flex-1">Have you gotten a breast cancer screening done?</span>
+                <select id="breast_screen" class="field">
+                  <option value="no">No</option>
+                  <option value="yes">Yes</option>
+                </select>
+              </label>
               <span class="block text-slate-600 text-sm">Helps detect breast cancer early.</span>
-            </label>
+            </div>
             <button type="button" class="what-btn" data-toggle="disc-screen" aria-expanded="false" aria-controls="disc-screen">What is this?</button>
             <small id="disc-screen" class="disclaimer" hidden>Modeled as additive life-years/QALYs from published decision analyses.</small>
           </fieldset>

--- a/js/app.js
+++ b/js/app.js
@@ -33,7 +33,7 @@ function wireUI() {
     document.getElementById('ysq-wrap').hidden = (v !== 'former');
     alcoholWrap.hidden = (v !== 'current');
     if (v !== 'current') {
-      document.getElementById('alcohol').value = 0;
+      document.getElementById('alcohol').value = '0';
       update({ smoking: v, alcoholDrinks: 0 });
     } else {
       update({ smoking: v });
@@ -50,20 +50,20 @@ function wireUI() {
   bindNumber('weight', v => update({ weight: Math.max(50, +v||50) }), 'weight');
   bindNumber('heightFeet', v => update({ heightFt: Math.max(3, +v||3) }), 'heightFt');
   bindNumber('heightInches', v => update({ heightIn: Math.max(0, Math.min(11, +v||0)) }), 'heightIn');
-  bindNumber('alcohol', v => update({ alcoholDrinks: Math.max(0, +v||0) }), 'alcoholDrinks');
+  bindSelect('alcohol', v => update({ alcoholDrinks: Math.max(0, +v||0) }), 'alcoholDrinks');
 
   alcoholWrap.hidden = (s.smoking !== 'current');
   if (s.smoking !== 'current') {
-    document.getElementById('alcohol').value = 0;
+    document.getElementById('alcohol').value = '0';
     update({ alcoholDrinks: 0 });
   }
 
   const crcEl = document.getElementById('crc_screen');
-  crcEl.checked = s.crc;
-  crcEl.addEventListener('change', e => update({ crc: e.target.checked }));
+  crcEl.value = s.crc ? 'yes' : 'no';
+  crcEl.addEventListener('change', e => update({ crc: e.target.value === 'yes' }));
   const breastEl = document.getElementById('breast_screen');
-  breastEl.checked = s.breast;
-  breastEl.addEventListener('change', e => update({ breast: e.target.checked }));
+  breastEl.value = s.breast ? 'yes' : 'no';
+  breastEl.addEventListener('change', e => update({ breast: e.target.value === 'yes' }));
   document.getElementById('qualityToggle').addEventListener('change', e => update({ quality: e.target.checked }));
   document.getElementById('runBtn').addEventListener('click', run);
 
@@ -99,8 +99,8 @@ function wireUI() {
     const showBreast = sex==='F' && age>=40 && age<=74;
     crcWrap.hidden = !showCRC;
     breastWrap.hidden = !showBreast;
-    if(!showCRC && getState().crc){ crcEl.checked=false; setState({crc:false}); }
-    if(!showBreast && getState().breast){ breastEl.checked=false; setState({breast:false}); }
+    if(!showCRC && getState().crc){ crcEl.value='no'; setState({crc:false}); }
+    if(!showBreast && getState().breast){ breastEl.value='no'; setState({breast:false}); }
     fs.hidden = !showCRC && !showBreast;
   }
 }

--- a/js/charts.js
+++ b/js/charts.js
@@ -3,7 +3,7 @@ export function drawLines(containerId, series, opts={}){
   const el = document.getElementById(containerId);
   if (!el) return;
   el.innerHTML = '';
-  const W = el.clientWidth || 640, H = el.clientHeight || 280, m={t:20,r:15,b:40,l:40};
+  const W = el.clientWidth || 640, H = el.clientHeight || 280, m={t:30,r:20,b:60,l:50};
   const svg = h('svg',{viewBox:`0 0 ${W} ${H}`,width:'100%',height:'100%',role:'img'});
   el.appendChild(svg);
 
@@ -20,19 +20,19 @@ export function drawLines(containerId, series, opts={}){
   // axes
   line(m.l,H-m.b,W-m.r,H-m.b, '#aaa'); // x
   line(m.l,m.t,m.l,H-m.b, '#aaa');     // y
-  text(m.l, m.t-6, opts.yLabel||'', 'start');
-  text(W-m.r, H-m.b+22, opts.xLabel||'', 'end');
+  text(m.l, m.t-12, opts.yLabel||'', 'start');
+  text(W-m.r, H-m.b+30, opts.xLabel||'', 'end');
 
   // ticks (simple)
   for (let a = Math.ceil(xMin/10)*10; a<=xMax; a+=10){
-    const x=sx(a); line(x,H-m.b,x,H-m.b+4,'#aaa'); text(x,H-m.b+18,''+a,'middle');
+    const x=sx(a); line(x,H-m.b,x,H-m.b+6,'#aaa'); text(x,H-m.b+24,''+a,'middle');
   }
   const yStep = opts.yPercent ? 0.25 : 0.25;
   for (let p=0; p<=1.0001; p+=yStep){
     const y=sy(p);
     const label = opts.yPercent ? `${Math.round(p*100)}%` : ''+p;
-    line(m.l,y,m.l-4,y,'#aaa');
-    text(m.l-8,y,label,'end','middle');
+    line(m.l,y,m.l-6,y,'#aaa');
+    text(m.l-12,y,label,'end','middle');
   }
 
   // lines
@@ -47,7 +47,7 @@ export function drawLines(containerId, series, opts={}){
   });
 
   if (opts.disclaimer){
-    text(W-10, H-6, 'Population-level; period table; associations; see Assumptions.', 'end', 'baseline', '0.75em');
+    text(W-10, H-12, 'Population-level; period table; associations; see Assumptions.', 'end', 'baseline', '0.75em');
   }
 
   function h(tag,attrs){ const e=document.createElementNS('http://www.w3.org/2000/svg',tag); for(const k in attrs) e.setAttribute(k,attrs[k]); return e; }


### PR DESCRIPTION
## Summary
- Change alcohol input to a select dropdown
- Replace screening checkboxes with yes/no dropdowns
- Widen chart margins for better label and note spacing

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a505ac75708322afb5fcf194ab8b2e