### PR TITLE
Move chart titles and disclaimers outside graphs

### DIFF
--- a/js/app.js
+++ b/js/app.js
@@ -141,14 +141,14 @@ function onWorkerMessage(e) {
   drawLines('survivalChart', [
     { name:'Baseline', x: msg.survival.age, y: msg.survival.S_base },
     { name:'Adjusted', x: msg.survival.age, y: msg.survival.S_adj }
-  ], { yLabel:'Survival', xLabel:'Age', yPercent:true, disclaimer:true });
+  ], { title:'Survival', xLabel:'Age', yPercent:true, disclaimer:true });
 
   const oneMinusS = msg.survival.S_base.map((v,i)=>1-v);
   const oneMinusSa= msg.survival.S_adj.map((v,i)=>1-v);
   drawLines('cdfChart', [
     { name:'Baseline', x: msg.survival.age, y: oneMinusS },
     { name:'Adjusted', x: msg.survival.age, y: oneMinusSa }
-  ], { yLabel:'Cumulative probability of death', xLabel:'Age', yPercent:true, disclaimer:true });
+  ], { title:'Cumulative probability of death', xLabel:'Age', yPercent:true, disclaimer:true });
 }
 
 function getStateForWorker(){

--- a/js/charts.js
+++ b/js/charts.js
@@ -3,8 +3,18 @@ export function drawLines(containerId, series, opts={}){
   const el = document.getElementById(containerId);
   if (!el) return;
   el.innerHTML = '';
-  const W = el.clientWidth || 640, H = el.clientHeight || 280, m={t:30,r:20,b:60,l:50};
-  const svg = h('svg',{viewBox:`0 0 ${W} ${H}`,width:'100%',height:'100%',role:'img'});
+  const W = el.clientWidth || 640;
+  const H = opts.height || 280;
+  const m = {t:30,r:20,b:60,l:50};
+
+  if (opts.title){
+    const t = document.createElement('div');
+    t.className = 'chart-title';
+    t.textContent = opts.title;
+    el.appendChild(t);
+  }
+
+  const svg = h('svg',{viewBox:`0 0 ${W} ${H}`,width:'100%',height:H,role:'img'});
   el.appendChild(svg);
 
   // Flatten domains
@@ -20,7 +30,6 @@ export function drawLines(containerId, series, opts={}){
   // axes
   line(m.l,H-m.b,W-m.r,H-m.b, '#aaa'); // x
   line(m.l,m.t,m.l,H-m.b, '#aaa');     // y
-  text(m.l, m.t-12, opts.yLabel||'', 'start');
   text(W-m.r, H-m.b+30, opts.xLabel||'', 'end');
 
   // ticks (simple)
@@ -47,7 +56,10 @@ export function drawLines(containerId, series, opts={}){
   });
 
   if (opts.disclaimer){
-    text(W-10, H-12, 'Population-level; period table; associations; see Assumptions.', 'end', 'baseline', '0.75em');
+    const note = document.createElement('div');
+    note.className = 'chart-note';
+    note.textContent = 'Population-level; period table; associations; see Assumptions.';
+    el.appendChild(note);
   }
 
   function h(tag,attrs){ const e=document.createElementNS('http://www.w3.org/2000/svg',tag); for(const k in attrs) e.setAttribute(k,attrs[k]); return e; }

--- a/style.css
+++ b/style.css
@@ -56,8 +56,12 @@ input[type="checkbox"]{ min-width:44px; }
 .stat-label{font-size:.9rem;opacity:.8}
 .stat-value{font-size:1.25rem;font-weight:600}
 .stat-delta{color:var(--accent,#1a7f37)}
-.chart{height:280px;margin-bottom:1rem}
+
+.chart{margin-bottom:1rem}
+.chart svg{height:280px;width:100%}
 .chart + .chart{margin-top:1rem}
+.chart-title{font-weight:600;text-align:center;margin-bottom:.25rem}
+.chart-note{font-size:.75rem;opacity:.8;text-align:right;margin-top:.25rem}
 .graph-divider{border-top:2px solid #e5e7eb;margin:1.5rem 0}
 .inline{display:flex;align-items:center;gap:.5rem}
 .disclaimer{font-size:.85rem;opacity:.8}
@@ -67,7 +71,8 @@ input[type="checkbox"]{ min-width:44px; }
 .contrib .chip{display:inline-block;margin:.125rem .25rem;padding:.25rem .5rem;border-radius:999px;background:var(--chip,#f1f1f1);font-size:.85rem}
 
 @media(max-width:600px){
-  .chart{height:200px;margin:.5rem 0}
+  .chart{margin:.5rem 0}
+  .chart svg{height:200px}
   .chart + .chart{margin-top:.5rem}
 }
 


### PR DESCRIPTION
## Summary
- Display chart titles above SVG graphs and move disclaimers below to prevent overlap
- Update styling for new chart title/note elements and responsive heights

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a50b2a482c8322b223d51c9623e6e2