### PR TITLE
Add solid social icons and adjust chart spacing

### DIFF
--- a/index.html
+++ b/index.html
@@ -37,9 +37,19 @@
         <p class="text-slate-600">Crunch the numbers and outwit risk.</p>
       </div>
       <div class="flex items-center gap-4 text-sm">
-        <a class="inline-flex items-center gap-1 underline" href="https://instagram.com/luisitin2001" target="_blank" rel="noopener">Instagram</a>
+        <a class="inline-flex items-center gap-1 underline" href="https://instagram.com/luisitin2001" target="_blank" rel="noopener">
+          <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" class="w-4 h-4" fill="currentColor">
+            <path d="M7 2h10a5 5 0 0 1 5 5v10a5 5 0 0 1-5 5H7a5 5 0 0 1-5-5V7a5 5 0 0 1 5-5zm0 2a3 3 0 0 0-3 3v10a3 3 0 0 0 3 3h10a3 3 0 0 0 3-3V7a3 3 0 0 0-3-3H7zm5 3.5a5.5 5.5 0 1 1 0 11 5.5 5.5 0 0 1 0-11zm0 2a3.5 3.5 0 1 0 0 7 3.5 3.5 0 0 0 0-7zM18 6.2a1 1 0 1 1 0 2 1 1 0 0 1 0-2z"/>
+          </svg>
+          Instagram
+        </a>
         <span class="text-slate-400">&bull;</span>
-        <a class="inline-flex items-center gap-1 underline" href="https://www.tiktok.com/@luisitin2001" target="_blank" rel="noopener">TikTok</a>
+        <a class="inline-flex items-center gap-1 underline" href="https://www.tiktok.com/@luisitin2001" target="_blank" rel="noopener">
+          <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 48 48" class="w-4 h-4" fill="currentColor">
+            <path d="M30 6c1.6 3.6 4.6 6.3 8.3 7.2v6.1c-3.2-.1-6.2-1.1-8.7-2.8v12.3c0 7.1-5.7 12.8-12.8 12.8S4 35.9 4 28.8s5.7-12.8 12.8-12.8c1.2 0 2.4.2 3.5.5v6.4c-.9-.4-1.9-.6-3-.6-3.4 0-6.3 2.8-6.3 6.3s2.8 6.3 6.3 6.3 6.3-2.8 6.3-6.3V6h6.4z"/>
+          </svg>
+          TikTok
+        </a>
       </div>
     </div>
     <div class="mt-3 flex items-center justify-between text-sm text-slate-600 px-3 py-2 bg-white rounded-lg border">

--- a/js/charts.js
+++ b/js/charts.js
@@ -30,7 +30,7 @@ export function drawLines(containerId, series, opts={}){
   // axes
   line(m.l,H-m.b,W-m.r,H-m.b, '#aaa'); // x
   line(m.l,m.t,m.l,H-m.b, '#aaa');     // y
-  text(W-m.r, H-m.b+30, opts.xLabel||'', 'end');
+  text(W-m.r, H-m.b+40, opts.xLabel||'', 'end');
 
   // ticks (simple)
   for (let a = Math.ceil(xMin/10)*10; a<=xMax; a+=10){

--- a/style.css
+++ b/style.css
@@ -60,8 +60,8 @@ input[type="checkbox"]{ min-width:44px; }
 .chart{margin-bottom:1rem}
 .chart svg{height:280px;width:100%}
 .chart + .chart{margin-top:1rem}
-.chart-title{font-weight:600;text-align:center;margin-bottom:.25rem}
-.chart-note{font-size:.75rem;opacity:.8;text-align:right;margin-top:.25rem}
+.chart-title{font-weight:600;text-align:center;margin-bottom:.5rem}
+.chart-note{font-size:.75rem;opacity:.8;text-align:right;margin-top:.5rem}
 .graph-divider{border-top:2px solid #e5e7eb;margin:1.5rem 0}
 .inline{display:flex;align-items:center;gap:.5rem}
 .disclaimer{font-size:.85rem;opacity:.8}


### PR DESCRIPTION
## Summary
- Inline solid Instagram and TikTok SVG icons to replace transparent social icons.
- Increase chart title and note margins and move x‑axis label lower for better spacing.

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a50cbe9034832283da702e0518c3dd