### PR TITLE
Ensure header text visible without animation

### DIFF
--- a/index.html
+++ b/index.html
@@ -30,10 +30,10 @@
 </head>
 <body class="bg-slate-50 text-slate-900 antialiased">
   <header class="max-w-5xl mx-auto px-4 py-6 bg-white rounded-xl shadow">
-    <div class="flex flex-col sm:flex-row items-start sm:items-center gap-4 mb-4 animate-fadeUp">
-      <div class="w-16 h-16 rounded-2xl bg-yellow-100 flex items-center justify-center text-3xl shadow bouncy select-none" aria-hidden="true" title="Hi!">🙂</div>
+    <div class="flex flex-col sm:flex-row items-start sm:items-center gap-4 mb-4 motion-safe:animate-fadeUp">
+      <div class="w-16 h-16 rounded-2xl bg-yellow-100 flex items-center justify-center text-3xl shadow bouncy select-none text-slate-900" aria-hidden="true" title="Hi!">🙂</div>
       <div class="flex-1 min-w-0">
-        <h1 class="text-2xl md:text-3xl font-bold tracking-tight">Actuarial Toolkit</h1>
+        <h1 class="text-2xl md:text-3xl font-bold tracking-tight text-slate-900">Actuarial Toolkit</h1>
         <p class="text-slate-600">Crunch the numbers and outwit risk.</p>
       </div>
       <div class="flex items-center gap-4 text-sm">
@@ -54,8 +54,8 @@
     </div>
     <div class="mt-3 flex items-center justify-between text-sm text-slate-600 px-3 py-2 bg-white rounded-lg border">
       <div class="flex items-center gap-2">
-        <span class="px-2 py-0.5 rounded bg-slate-100">Fun fact</span>
-        <span id="fun-fact" class="animate-fadeUp text-slate-600"></span>
+        <span class="px-2 py-0.5 rounded bg-slate-100 text-slate-600">Fun fact</span>
+        <span id="fun-fact" class="motion-safe:animate-fadeUp text-slate-600"></span>
       </div>
       <button id="shuffle-fact" class="icon-btn hover:bg-slate-100" aria-label="Shuffle fun fact" title="Shuffle fun fact">
         <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" class="w-4 h-4" fill="currentColor">


### PR DESCRIPTION
## Summary
- force header smiley icon and title to use dark text classes
- apply `motion-safe` to fade-up animations so text stays visible when reduced-motion is enabled
- explicitly color fun-fact label to keep ribbon readable

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a50f0f1d7483228f8c99977b82dd25