### PR TITLE
Always ask about alcohol and fix mobile tooltip toggle

### DIFF
--- a/index.html
+++ b/index.html
@@ -145,7 +145,7 @@
                 <input id="yearsSinceQuit" class="field" type="number" min="0" max="60" placeholder="5" aria-describedby="ysq-tip" />
               </label>
 
-              <label id="alcohol-wrap" class="inline" hidden>Alcohol (drinks/day)
+              <label id="alcohol-wrap" class="inline">Alcohol (drinks/day)
                 <button type="button" class="icon-btn" aria-label="Alcohol info">
                   i
                   <span class="tooltip" role="tooltip" id="alcohol-tip">

--- a/js/app.js
+++ b/js/app.js
@@ -28,16 +28,9 @@ function wireUI() {
   // Inputs
   bindNumber('age', v => update({ age: clamp(+v,20,100) }));
   bindSelect('sex', v => update({ sex: v }));
-  const alcoholWrap = document.getElementById('alcohol-wrap');
   bindSelect('smoking', v => {
     document.getElementById('ysq-wrap').hidden = (v !== 'former');
-    alcoholWrap.hidden = (v !== 'current');
-    if (v !== 'current') {
-      document.getElementById('alcohol').value = '0';
-      update({ smoking: v, alcoholDrinks: 0 });
-    } else {
-      update({ smoking: v });
-    }
+    update({ smoking: v });
   });
   bindNumber('yearsSinceQuit', v => update({ yearsSinceQuit: Math.max(0, +v||0) }));
 
@@ -51,12 +44,6 @@ function wireUI() {
   bindNumber('heightFeet', v => update({ heightFt: Math.max(3, +v||3) }), 'heightFt');
   bindNumber('heightInches', v => update({ heightIn: Math.max(0, Math.min(11, +v||0)) }), 'heightIn');
   bindSelect('alcohol', v => update({ alcoholDrinks: Math.max(0, +v||0) }), 'alcoholDrinks');
-
-  alcoholWrap.hidden = (s.smoking !== 'current');
-  if (s.smoking !== 'current') {
-    document.getElementById('alcohol').value = '0';
-    update({ alcoholDrinks: 0 });
-  }
 
   const crcEl = document.getElementById('crc_screen');
   crcEl.value = s.crc ? 'yes' : 'no';

--- a/js/ui.js
+++ b/js/ui.js
@@ -76,22 +76,14 @@ import { setState, getState } from './state.js';
     icons.forEach(btn=>{
       const tip = btn.querySelector('.tooltip');
       if(!tip) return;
-      let openT, closeT;
       const open = ()=>{
-        clearTimeout(closeT);
-        if(btn.hasAttribute('data-open')) return;
-        openT = setTimeout(()=>{
-          closeAll();
-          btn.setAttribute('data-open','');
-          positionTooltip(btn);
-        }, 100);
+        closeAll();
+        btn.setAttribute('data-open','');
+        positionTooltip(btn);
       };
       const close = ()=>{
-        clearTimeout(openT);
-        closeT = setTimeout(()=>{
-          btn.removeAttribute('data-open');
-          tip.removeAttribute('style');
-        }, 100);
+        btn.removeAttribute('data-open');
+        tip.removeAttribute('style');
       };
       btn.addEventListener('mouseenter', open);
       btn.addEventListener('focus', open);


### PR DESCRIPTION
## Summary
- Always display alcohol consumption selector instead of tying it to smoking status
- Simplify tooltip open/close logic so info buttons work reliably on mobile

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a510c0e2d48322ac29fea71bb909ac