### PR TITLE
Display survival data conditional on current age

### DIFF
--- a/js/app.js
+++ b/js/app.js
@@ -124,17 +124,22 @@ function onWorkerMessage(e) {
     c.appendChild(span);
   });
 
-  // charts
+  // charts (conditional on current age)
+  const idx = msg.survival.age.findIndex(a => a >= currentAge);
+  const ages = msg.survival.age.slice(idx);
+  const baseCond = msg.survival.S_base.slice(idx).map(v => v / msg.survival.S_base[idx]);
+  const adjCond  = msg.survival.S_adj.slice(idx).map(v => v / msg.survival.S_adj[idx]);
+
   drawLines('survivalChart', [
-    { name:'Baseline', x: msg.survival.age, y: msg.survival.S_base },
-    { name:'Adjusted', x: msg.survival.age, y: msg.survival.S_adj }
+    { name:'Baseline', x: ages, y: baseCond },
+    { name:'Adjusted', x: ages, y: adjCond }
   ], { title:'Survival', xLabel:'Age', yPercent:true, disclaimer:true });
 
-  const oneMinusS = msg.survival.S_base.map((v,i)=>1-v);
-  const oneMinusSa= msg.survival.S_adj.map((v,i)=>1-v);
+  const oneMinusS  = baseCond.map(v=>1-v);
+  const oneMinusSa = adjCond.map(v=>1-v);
   drawLines('cdfChart', [
-    { name:'Baseline', x: msg.survival.age, y: oneMinusS },
-    { name:'Adjusted', x: msg.survival.age, y: oneMinusSa }
+    { name:'Baseline', x: ages, y: oneMinusS },
+    { name:'Adjusted', x: ages, y: oneMinusSa }
   ], { title:'Cumulative probability of death', xLabel:'Age', yPercent:true, disclaimer:true });
 }
 

--- a/tests/tests.html
+++ b/tests/tests.html
@@ -1,5 +1,6 @@
 <!doctype html>
 <meta charset="utf-8">
+<base href="..">
 <title>Longevity Lab Tests</title>
 <p>Open console for results.</p>
 <script type="module">
@@ -19,5 +20,13 @@
   const currentSmoker = await run({sex:'M', age:35, smoking:{status:'current'}, metHours:0, bmi:27.5, alcoholDrinks:2, screening:{crc:false,breast:false}, quality:false});
   console.assert(currentSmoker.le_adj < base.le_baseline, 'Smoking reduces LE');
 
+  // survival conditional on current age should start at 1 and death CDF at 0
+  const age = 35;
+  const cond = base.survival.S_base.slice(age).map(v=>v/base.survival.S_base[age]);
+  console.assert(Math.abs(cond[0]-1) < 1e-9, 'Conditional survival starts at 1');
+  const cdfCond = cond.map(v=>1-v);
+  console.assert(Math.abs(cdfCond[0]) < 1e-9, 'Conditional death CDF starts at 0');
+
   console.log('Tests ran. Results:', {base, active, currentSmoker});
+  window.testsDone = true;
 </script>

--- a/workers/longevityWorker.js
+++ b/workers/longevityWorker.js
@@ -5,8 +5,9 @@
 // importScripts; // no-op hint for bundlers (kept for bundlers, safe if undefined)
 
 let life, hrAct, hrBmi, hrSmoke, hrAlc, haleWeights, screening_crc, screening_breast;
+const ctx = typeof self !== 'undefined' ? self : globalThis;
 
-self.onmessage = (e)=>{
+ctx.onmessage = (e)=>{
   const {cmd, payload} = e.data;
   if (cmd==='init'){
     // Datasets are passed in as blobs from dataLoader
@@ -19,11 +20,11 @@ self.onmessage = (e)=>{
     haleWeights = d['hale_weights'] || null;
     screening_crc = d['screening_crc'] || null;
     screening_breast = d['screening_breast'] || null;
-    self.postMessage({ready:true});
+    ctx.postMessage({ready:true});
     return;
   }
   if (cmd==='run'){
-    self.postMessage(runModel(payload));
+    ctx.postMessage(runModel(payload));
   }
 };
 


### PR DESCRIPTION
## Summary
- normalize survival and death probability charts so they are conditional on the selected current age
- allow longevity worker to run in Node for tests
- add tests confirming conditional survival probabilities

## Testing
- `node --input-type=module - <<'NODE'
import { chromium } from 'playwright';
const browser = await chromium.launch();
const page = await browser.newPage();
page.on('console', msg => console.log(msg.text()));
await page.goto('http://localhost:3000/tests/tests.html');
await page.waitForFunction(() => window.testsDone === true);
await browser.close();
NODE`


------
https://chatgpt.com/codex/tasks/task_e_68a514c5563883229c828d3215008959