### PR TITLE
Fix mobile tooltip interaction and remove page translucency

### DIFF
--- a/index.html
+++ b/index.html
@@ -75,7 +75,7 @@
     </div>
   </section>
 
-  <div class="pointer-events-none fixed inset-0 overflow-hidden" aria-hidden="true">
+  <div class="pointer-events-none fixed inset-0 overflow-hidden -z-10" aria-hidden="true">
     <div class="absolute -top-24 -left-24 w-72 h-72 rounded-full bg-gradient-to-br from-amber-200 to-pink-200 blur-3xl opacity-60 animate-floaty"></div>
     <div class="absolute -bottom-24 -right-24 w-80 h-80 rounded-full bg-gradient-to-br from-emerald-200 to-sky-200 blur-3xl opacity-60 animate-floaty" style="animation-delay:-2.2s;"></div>
   </div>

--- a/js/ui.js
+++ b/js/ui.js
@@ -86,7 +86,9 @@ import { setState, getState } from './state.js';
         tip.removeAttribute('style');
       };
       btn.addEventListener('mouseenter', open);
-      btn.addEventListener('focus', open);
+      if (window.matchMedia('(hover:hover) and (pointer:fine)').matches) {
+        btn.addEventListener('focus', open);
+      }
       btn.addEventListener('mouseleave', close);
       btn.addEventListener('blur', close);
       btn.addEventListener('click', ev=>{

--- a/style.css
+++ b/style.css
@@ -17,8 +17,8 @@ body {
 
 /* Card container used by <Section> */
 .card {
-  background: rgba(255,255,255,.75);
-  backdrop-filter: saturate(140%) blur(6px);
+  background: white;
+  backdrop-filter: none;
   border: 1px solid rgba(15, 23, 42, .08);
   border-radius: 16px;
   box-shadow: 0 4px 14px rgba(2, 6, 23, .04);
@@ -100,7 +100,7 @@ body {
   z-index: 40;
 }
 .icon-btn:hover .tooltip,
-.icon-btn:focus-visible .tooltip{
+.icon-btn:focus .tooltip{
   pointer-events: auto;
   opacity: 1;
   transform: translateX(-50%) translateY(10px) scale(1);

--- a/theme/style.css
+++ b/theme/style.css
@@ -17,8 +17,8 @@ body {
 
 /* Card container used by <Section> */
 .card {
-  background: rgba(255,255,255,.75);
-  backdrop-filter: saturate(140%) blur(6px);
+  background: white;
+  backdrop-filter: none;
   border: 1px solid rgba(15, 23, 42, .08);
   border-radius: 16px;
   box-shadow: 0 4px 14px rgba(2, 6, 23, .04);
@@ -112,6 +112,12 @@ body {
   border-top:1px solid rgba(15,23,42,.12);
 }
 .icon-btn[data-open] .tooltip{
+  pointer-events: auto;
+  opacity: 1;
+  transform: translateX(-50%) translateY(10px) scale(1);
+}
+.icon-btn:hover .tooltip,
+.icon-btn:focus .tooltip{
   pointer-events: auto;
   opacity: 1;
   transform: translateX(-50%) translateY(10px) scale(1);


### PR DESCRIPTION
## Summary
- Ensure background gradient sits behind content to eliminate translucency
- Open info tooltips on touch devices by guarding focus handler
- Use solid backgrounds for cards so sections are no longer translucent

## Testing
- `npm test` *(fails: ENOENT package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a51835d3288322a6de70898bb90847