### PR TITLE
Fix info buttons not showing text

### DIFF
--- a/style.css
+++ b/style.css
@@ -105,6 +105,12 @@ body {
   opacity: 1;
   transform: translateX(-50%) translateY(10px) scale(1);
 }
+/* allow tooltips to remain visible when toggled via JS */
+.icon-btn[data-open] .tooltip{
+  pointer-events: auto;
+  opacity: 1;
+  transform: translateX(-50%) translateY(10px) scale(1);
+}
 .tooltip-content{
   display:block;
   font-size: .78rem;


### PR DESCRIPTION
## Summary
- allow info button tooltips to stay visible after click by styling `[data-open]`

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a51cc49bc483228e30ac1adad9afb2