### PR TITLE
Redesign info button tooltips

### DIFF
--- a/index.html
+++ b/index.html
@@ -95,20 +95,16 @@
           <fieldset aria-describedby="disclaimer-controls">
             <legend>Profile</legend>
             <label class="inline">Age
-              <button type="button" class="icon-btn" aria-label="Age info">
+              <button type="button" class="icon-btn info-btn" aria-label="Age info">
                 i
-                <span class="tooltip" role="tooltip" id="age-tip">
-                  <span class="tooltip-content">Your current age. Used to look up the baseline mortality rate.</span>
-                </span>
+                <span class="info-tip" role="tooltip" id="age-tip">Your current age. Used to look up the baseline mortality rate.</span>
               </button>
               <input id="age" class="field" type="number" min="20" max="100" inputmode="numeric" placeholder="35" aria-describedby="age-tip" />
             </label>
             <label class="inline">Sex
-              <button type="button" class="icon-btn" aria-label="Sex info">
+              <button type="button" class="icon-btn info-btn" aria-label="Sex info">
                 i
-                <span class="tooltip" role="tooltip" id="sex-tip">
-                  <span class="tooltip-content">Biological sex (female or male). Determines which life table (F or M) to use.</span>
-                </span>
+                <span class="info-tip" role="tooltip" id="sex-tip">Biological sex (female or male). Determines which life table (F or M) to use.</span>
               </button>
               <select id="sex" class="field" aria-describedby="sex-tip">
                 <option value="F">Female</option>
@@ -123,11 +119,9 @@
               <hr class="my-4" />
 
               <label class="inline">Smoking
-                <button type="button" class="icon-btn" aria-label="Smoking info">
+                <button type="button" class="icon-btn info-btn" aria-label="Smoking info">
                   i
-                  <span class="tooltip" role="tooltip" id="smoking-tip">
-                    <span class="tooltip-content">Select ‘Never’ if you’ve never smoked, ‘Current’ if you smoke now, or ‘Former’ if you quit.</span>
-                  </span>
+                  <span class="info-tip" role="tooltip" id="smoking-tip">Select ‘Never’ if you’ve never smoked, ‘Current’ if you smoke now, or ‘Former’ if you quit.</span>
                 </button>
                 <select id="smoking" class="field" aria-describedby="smoking-tip">
                   <option value="never">Never</option>
@@ -137,21 +131,17 @@
               </label>
 
               <label id="ysq-wrap" class="inline" hidden>Years since quit
-                <button type="button" class="icon-btn" aria-label="Years since quit info">
+                <button type="button" class="icon-btn info-btn" aria-label="Years since quit info">
                   i
-                  <span class="tooltip" role="tooltip" id="ysq-tip">
-                    <span class="tooltip-content">If you used to smoke, how many years ago you quit. Reduces your hazard ratio as the years increase.</span>
-                  </span>
+                  <span class="info-tip" role="tooltip" id="ysq-tip">If you used to smoke, how many years ago you quit. Reduces your hazard ratio as the years increase.</span>
                 </button>
                 <input id="yearsSinceQuit" class="field" type="number" min="0" max="60" placeholder="5" aria-describedby="ysq-tip" />
               </label>
 
               <label id="alcohol-wrap" class="inline">Alcohol (drinks/day)
-                <button type="button" class="icon-btn" aria-label="Alcohol info">
+                <button type="button" class="icon-btn info-btn" aria-label="Alcohol info">
                   i
-                  <span class="tooltip" role="tooltip" id="alcohol-tip">
-                    <span class="tooltip-content">Average number of standard drinks you have per day.</span>
-                  </span>
+                  <span class="info-tip" role="tooltip" id="alcohol-tip">Average number of standard drinks you have per day.</span>
                 </button>
                 <select id="alcohol" class="field" aria-describedby="alcohol-tip">
                   <option value="0">None</option>
@@ -167,11 +157,9 @@
               <hr class="my-4" />
 
               <label class="inline">Physical activity
-                <button type="button" class="icon-btn" aria-label="Physical activity info">
+                <button type="button" class="icon-btn info-btn" aria-label="Physical activity info">
                   i
-                  <span class="tooltip" role="tooltip" id="activity-tip">
-                    <span class="tooltip-content">Select your typical weekly activity. We'll estimate MET-hours/week.</span>
-                  </span>
+                  <span class="info-tip" role="tooltip" id="activity-tip">Select your typical weekly activity. We'll estimate MET-hours/week.</span>
                 </button>
                 <select id="activityLevel" class="field" aria-describedby="activity-tip">
                   <option value="none">Little to none</option>
@@ -182,21 +170,17 @@
               </label>
 
               <label class="inline">Weight (lbs)
-                <button type="button" class="icon-btn" aria-label="Weight info">
+                <button type="button" class="icon-btn info-btn" aria-label="Weight info">
                   i
-                <span class="tooltip" role="tooltip" id="weight-tip">
-                  <span class="tooltip-content">Your weight in pounds (lbs). Used to compute Body Mass Index (BMI).</span>
-                </span>
+                <span class="info-tip" role="tooltip" id="weight-tip">Your weight in pounds (lbs). Used to compute Body Mass Index (BMI).</span>
               </button>
               <input id="weight" class="field" type="number" min="50" max="1000" step="0.1" placeholder="160" aria-describedby="weight-tip" />
             </label>
 
               <label class="inline">Height
-                <button type="button" class="icon-btn" aria-label="Height info">
+                <button type="button" class="icon-btn info-btn" aria-label="Height info">
                   i
-                  <span class="tooltip" role="tooltip" id="height-tip">
-                    <span class="tooltip-content">Your height in feet and inches. Also used to compute BMI.</span>
-                  </span>
+                  <span class="info-tip" role="tooltip" id="height-tip">Your height in feet and inches. Also used to compute BMI.</span>
                 </button>
                 <div class="flex items-center gap-2">
                   <input id="heightFeet" class="field w-16" type="number" min="3" max="8" step="1" placeholder="5" aria-label="Height feet" aria-describedby="height-tip" /> <span>ft</span>
@@ -214,11 +198,9 @@
 
           <fieldset id="screening_fs">
             <legend class="inline">Preventive screening
-              <button type="button" class="icon-btn" aria-label="Preventive screening info">
+              <button type="button" class="icon-btn info-btn" aria-label="Preventive screening info">
                 i
-                <span class="tooltip" role="tooltip" id="screening-tip">
-                  <span class="tooltip-content">Adds extra life-years based on USPSTF recommendations.</span>
-                </span>
+                <span class="info-tip" role="tooltip" id="screening-tip">Adds extra life-years based on USPSTF recommendations.</span>
               </button>
             </legend>
             <div id="crc_wrap" hidden>
@@ -248,11 +230,9 @@
           <label class="inline">
             <input id="qualityToggle" type="checkbox" aria-describedby="quality-tip" />
             Show quality-adjusted years
-            <button type="button" class="icon-btn" aria-label="Quality adjusted years info">
+            <button type="button" class="icon-btn info-btn" aria-label="Quality adjusted years info">
               i
-              <span class="tooltip" role="tooltip" id="quality-tip">
-                <span class="tooltip-content">When on, uses healthy life expectancy (HALE) and QALY gains instead of plain life expectancy.</span>
-              </span>
+              <span class="info-tip" role="tooltip" id="quality-tip">When on, uses healthy life expectancy (HALE) and QALY gains instead of plain life expectancy.</span>
             </button>
           </label>
 
@@ -268,11 +248,9 @@
 
         <div id="summary" aria-live="polite">
           <div class="flex justify-end mb-2">
-            <button type="button" class="icon-btn" aria-label="Life expectancy explanations">
+            <button type="button" class="icon-btn info-btn" aria-label="Life expectancy explanations">
               i
-              <span class="tooltip" role="tooltip" id="summary-tip">
-                <span class="tooltip-content">Life expectancy is total expected years. Healthy life expectancy counts only years in good health.</span>
-              </span>
+              <span class="info-tip" role="tooltip" id="summary-tip">Life expectancy is total expected years. Healthy life expectancy counts only years in good health.</span>
             </button>
           </div>
 

--- a/js/ui.js
+++ b/js/ui.js
@@ -2,21 +2,8 @@
 import { setState, getState } from './state.js';
 
 (function(){
-  function positionTooltip(btn){
-    const tip = btn.querySelector('.tooltip');
-    if(!tip) return;
-    const rect = tip.getBoundingClientRect();
-    const vpCenter = window.innerWidth/2;
-    const arrow = Math.max(8, Math.min(rect.width-8, vpCenter - rect.left));
-    tip.style.setProperty('--arrow-left', `${arrow}px`);
-  }
-
-  function closeAll(){
-    document.querySelectorAll('.icon-btn[data-open]').forEach(btn=>{
-      btn.removeAttribute('data-open');
-      const tip = btn.querySelector('.tooltip');
-      if(tip) tip.removeAttribute('style');
-    });
+  function closeTips(){
+    document.querySelectorAll('.info-btn[data-open]').forEach(btn => btn.removeAttribute('data-open'));
   }
 
   document.addEventListener('change', e=>{
@@ -71,41 +58,28 @@ import { setState, getState } from './state.js';
       show(buttons[0].getAttribute('data-tool'));
     }
 
-    // tooltip toggling
-    const icons = document.querySelectorAll('.icon-btn');
-    icons.forEach(btn=>{
-      const tip = btn.querySelector('.tooltip');
+    // info tooltip toggling
+    const infos = document.querySelectorAll('.info-btn');
+    infos.forEach(btn => {
+      const tip = btn.querySelector('.info-tip');
       if(!tip) return;
-      const open = ()=>{
-        closeAll();
-        btn.setAttribute('data-open','');
-        positionTooltip(btn);
-      };
-      const close = ()=>{
-        btn.removeAttribute('data-open');
-        tip.removeAttribute('style');
-      };
-      btn.addEventListener('mouseenter', open);
-      if (window.matchMedia('(hover:hover) and (pointer:fine)').matches) {
-        btn.addEventListener('focus', open);
-      }
-      btn.addEventListener('mouseleave', close);
-      btn.addEventListener('blur', close);
-      btn.addEventListener('click', ev=>{
+      btn.addEventListener('click', ev => {
         ev.stopPropagation();
-        if(btn.hasAttribute('data-open')) close(); else open();
+        const isOpen = btn.hasAttribute('data-open');
+        closeTips();
+        if(!isOpen){
+          const rect = btn.getBoundingClientRect();
+          const center = window.innerWidth / 2;
+          tip.classList.toggle('right', rect.left < center);
+          tip.classList.toggle('left', rect.left >= center);
+          btn.setAttribute('data-open','');
+        }
       });
     });
 
-    document.addEventListener('click', closeAll);
-    document.addEventListener('keydown', e=>{ if(e.key==='Escape') closeAll(); });
-
-    const reposition = ()=>{
-      const open = document.querySelector('.icon-btn[data-open]');
-      if(open) positionTooltip(open);
-    };
-    window.addEventListener('scroll', reposition, { passive:true });
-    window.addEventListener('resize', reposition);
+    document.addEventListener('click', closeTips);
+    document.addEventListener('keydown', e => { if(e.key==='Escape') closeTips(); });
+    window.addEventListener('resize', closeTips);
 
     // collapsible disclaimers and notes
     document.querySelectorAll('[data-toggle]').forEach(btn=>{

--- a/style.css
+++ b/style.css
@@ -80,12 +80,13 @@ body {
 }
 .icon-btn:active::after{ opacity:1; transform: scale(1.4); }
 
-/* Tooltip used by <Info> */
-.icon-btn .tooltip{
-  pointer-events: none;
+/* Info button tooltips */
+.info-btn{ position: relative; }
+.info-btn .info-tip{
+  display: none;
   position: absolute;
-  top: 110%; left: 50%;
-  transform: translateX(-50%) translateY(6px) scale(.98);
+  top: 50%;
+  transform: translateY(-50%);
   min-width: 200px;
   max-width: 280px;
   background: white;
@@ -93,35 +94,29 @@ body {
   padding: .6rem .7rem;
   border-radius: .6rem;
   box-shadow: 0 18px 40px rgba(2,6,23,.12);
-  opacity: 0;
-  transition:
-    opacity .18s var(--ease-out),
-    transform .18s var(--ease-out);
   z-index: 40;
 }
-.icon-btn:hover .tooltip,
-.icon-btn:focus .tooltip{
-  pointer-events: auto;
-  opacity: 1;
-  transform: translateX(-50%) translateY(10px) scale(1);
+.info-btn[data-open] .info-tip{ display: block; }
+.info-tip.left{ right: calc(100% + 8px); }
+.info-tip.right{ left: calc(100% + 8px); }
+.info-tip::before{
+  content:'';
+  position:absolute;
+  top:50%;
+  width:12px; height:12px;
+  background:inherit;
+  border:1px solid rgba(15,23,42,.12);
+  transform:translateY(-50%) rotate(45deg);
 }
-/* allow tooltips to remain visible when toggled via JS */
-.icon-btn[data-open] .tooltip{
-  pointer-events: auto;
-  opacity: 1;
-  transform: translateX(-50%) translateY(10px) scale(1);
+.info-tip.left::before{
+  right:-6px;
+  border-left:none;
+  border-bottom:none;
 }
-.tooltip-content{
-  display:block;
-  font-size: .78rem;
-  line-height: 1.05rem;
-  color: rgb(71,85,105);
-  margin-bottom: .35rem;
-}
-.icon-btn .tooltip a{
-  font-size: .78rem;
-  text-decoration: underline;
-  color: rgb(2,132,199);
+.info-tip.right::before{
+  left:-6px;
+  border-right:none;
+  border-top:none;
 }
 
 /* Shimmer / skeleton (fallback if Tailwind animate-pulse not present) */
@@ -168,7 +163,7 @@ section.card { animation: fadeUp .42s var(--ease-out) both; }
   .card,
   .animate-pulse,
   .icon-btn::after,
-  .icon-btn .tooltip{
+  .info-btn .info-tip{
     animation: none !important;
     transition: none !important;
   }

--- a/theme/style.css
+++ b/theme/style.css
@@ -80,12 +80,13 @@ body {
 }
 .icon-btn:active::after{ opacity:1; transform: scale(1.4); }
 
-/* Tooltip used by <Info> */
-.icon-btn .tooltip{
-  pointer-events: none;
+/* Info button tooltips */
+.info-btn{ position: relative; }
+.info-btn .info-tip{
+  display: none;
   position: absolute;
-  top: 110%; left: 50%;
-  transform: translateX(-50%) translateY(6px) scale(.98);
+  top: 50%;
+  transform: translateY(-50%);
   min-width: 200px;
   max-width: 280px;
   background: white;
@@ -93,46 +94,29 @@ body {
   padding: .6rem .7rem;
   border-radius: .6rem;
   box-shadow: 0 18px 40px rgba(2,6,23,.12);
-  opacity: 0;
-  --arrow-left:50%;
-  transition:
-    opacity .18s var(--ease-out),
-    transform .18s var(--ease-out);
   z-index: 40;
 }
-.icon-btn .tooltip::before{
+.info-btn[data-open] .info-tip{ display: block; }
+.info-tip.left{ right: calc(100% + 8px); }
+.info-tip.right{ left: calc(100% + 8px); }
+.info-tip::before{
   content:'';
   position:absolute;
-  top:-6px;
-  left:var(--arrow-left);
-  transform:translateX(-50%) rotate(45deg);
+  top:50%;
   width:12px; height:12px;
   background:inherit;
-  border-left:1px solid rgba(15,23,42,.12);
-  border-top:1px solid rgba(15,23,42,.12);
+  border:1px solid rgba(15,23,42,.12);
+  transform:translateY(-50%) rotate(45deg);
 }
-.icon-btn[data-open] .tooltip{
-  pointer-events: auto;
-  opacity: 1;
-  transform: translateX(-50%) translateY(10px) scale(1);
+.info-tip.left::before{
+  right:-6px;
+  border-left:none;
+  border-bottom:none;
 }
-.icon-btn:hover .tooltip,
-.icon-btn:focus .tooltip{
-  pointer-events: auto;
-  opacity: 1;
-  transform: translateX(-50%) translateY(10px) scale(1);
-}
-.tooltip-content{
-  display:block;
-  font-size: .78rem;
-  line-height: 1.05rem;
-  color: rgb(71,85,105);
-  margin-bottom: .35rem;
-}
-.icon-btn .tooltip a{
-  font-size: .78rem;
-  text-decoration: underline;
-  color: rgb(2,132,199);
+.info-tip.right::before{
+  left:-6px;
+  border-right:none;
+  border-top:none;
 }
 
 /* Shimmer / skeleton (fallback if Tailwind animate-pulse not present) */
@@ -179,7 +163,7 @@ section.card { animation: fadeUp .42s var(--ease-out) both; }
   .card,
   .animate-pulse,
   .icon-btn::after,
-  .icon-btn .tooltip{
+  .info-btn .info-tip{
     animation: none !important;
     transition: none !important;
   }


### PR DESCRIPTION
## Summary
- Replace legacy `(i)` tooltip implementation with new `info-btn`/`info-tip` components
- Orient tooltips toward screen center to avoid offscreen rendering
- Remove old tooltip styling and scripts

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a5df5e07a883228494f9385501c8e8